### PR TITLE
Add Slot, Machine and production schedule resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `Machine` and `Slot` resources, basic api retrieval for `Machine` production_schedule
 - Remove availabilities for machines and specialists (will be moved to the hub)
 
 ## [0.2.4]

--- a/lib/zaikio/mission_control.rb
+++ b/lib/zaikio/mission_control.rb
@@ -84,6 +84,8 @@ require "zaikio/mission_control/desired_substrate"
 require "zaikio/mission_control/finishing_application"
 require "zaikio/mission_control/finishing"
 require "zaikio/mission_control/file_reference"
+require "zaikio/mission_control/machine"
+require "zaikio/mission_control/slot"
 
 module Zaikio
   module MissionControl

--- a/lib/zaikio/mission_control/machine.rb
+++ b/lib/zaikio/mission_control/machine.rb
@@ -1,0 +1,11 @@
+module Zaikio
+  module MissionControl
+    class Machine < Base
+      def production_schedule_slots
+        @production_schedule_slots ||= get(:production_schedule)["production_schedule_slots"].map do |slot|
+          Zaikio::MissionControl::Slot.new(slot)
+        end
+      end
+    end
+  end
+end

--- a/lib/zaikio/mission_control/slot.rb
+++ b/lib/zaikio/mission_control/slot.rb
@@ -1,0 +1,8 @@
+module Zaikio
+  module MissionControl
+    class Slot < Base
+      attributes :started_at, :ended_at, :outdated, :workstep_id, :machine_id, :created_at, :updated_at,
+                 :production_frame_id, :updated_slot_id, :outdated_slot_id, :slot_candidate_id
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/machine_production_schedule.yml
+++ b/test/fixtures/vcr_cassettes/machine_production_schedule.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://mc.zaikio.test/api/v1/machines/b1cc3531-ea11-4f94-b35f-cccaaed4a4c5/production_schedule
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v1.10.3
+        Authorization:
+          - Bearer eyJraWQiOiI0ZmZhNTc5MmQwMTJlMjY0YTEzODk5ZmZkYTA3YmVhYzkwOTA4NjRhNmY4MWU5YjQxMGNkOTFkY2UxOTNlODg3IiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJaQUkiLCJzdWIiOiJPcmdhbml6YXRpb24vOWQ2YmExM2YtN2QzYi00ZjI4LWIzZTMtYmRiMThjOGEyNjY4IiwiYXVkIjpbImtleWxpbmVfY2xhc3NpYyJdLCJqdGkiOiI4ZTBiOTI0MC1mNTdjLTQ4MjMtYTlmMi1lYjZkMzhkZGNiYmQiLCJuYmYiOjE2ODA1OTM5MDMsImV4cCI6MTY4MDU5NzUwMywiamt1IjoiaHR0cHM6Ly9odWIuc2FuZGJveC56YWlraW8uY29tL2FwaS92MS9qd3RfcHVibGljX2tleXMiLCJzY29wZSI6WyJkaXJlY3RvcnkubWFjaGluZXMucnciLCJkaXJlY3Rvcnkub3JnYW5pemF0aW9uLnIiLCJkaXJlY3Rvcnkub3JnYW5pemF0aW9uX21lbWJlcnMucnciLCJkaXJlY3Rvcnkuc2l0ZXMucnciLCJkaXJlY3Rvcnkuc3BlY2lhbGlzdHMucnciLCJtaXNzaW9uX2NvbnRyb2wuY29tbWlzc2lvbmluZ3MucnciLCJtaXNzaW9uX2NvbnRyb2wuZXN0aW1hdGVzLnJ3IiwibWlzc2lvbl9jb250cm9sLmpvYnMucnciLCJtaXNzaW9uX2NvbnRyb2wubGlzdHMucnciLCJtaXNzaW9uX2NvbnRyb2wub3JkZXJzLnJ3IiwicHJvY3VyZW1lbnRfY29uc3VtZXIuYXJ0aWNsZV9iYXNlLnIiLCJwcm9jdXJlbWVudF9jb25zdW1lci5jb250cmFjdHMucnciLCJwcm9jdXJlbWVudF9jb25zdW1lci5tYXRlcmlhbF9yZXF1aXJlbWVudHMucnciLCJwcm9jdXJlbWVudF9jb25zdW1lci5vcmRlcnMucnciLCJ3YXJlaG91c2UuY29uc3VtcHRpb25zX2FuZF9yZXNlcnZhdGlvbnMucnciLCJ3YXJlaG91c2UuZmluaXNoZWRfZ29vZHNfY2FsbF9vZmZzLnIiLCJ3YXJlaG91c2Uuc3RvY2tfbGV2ZWxzLnJ3Iiwid2FyZWhvdXNlLndhcmVob3VzZXMucnciXX0.vyJ1Q8UsYbNTBIalGxYcTao6CdqTjwPvAsdw8P3A84XGJeggeyMjiPbqioOr6AXhwpFjqrcjYw2xms69RTIDT_EYs6_0JzJQMujtuq04hqIPx2oOphMKCgjcoVkSjsnl--lW_qZj-FCVbcXoV9KQmVm7cfQK6pzA6k-1Qf_3ln-mvN32nOE7JPO6fDl_yebUpfvOKlgultLxxDtM8nHhiArpCvp5StZlFUVjUUhb_qI6uX58Z9Wk3j-7WrOdjtvtaN0CrknKV8GPWQNJMlWrF1uqA3t5X-KWRi5NyzeqgRZQ_t5Wcig_uMbrIn5cPt4dUdiaceQdzfzGm9wON00MhA
+        Accept-Language:
+          - en
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - Cowboy
+        Date:
+          - Tue, 04 Apr 2023 07:40:11 GMT
+        Connection:
+          - keep-alive
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Xss-Protection:
+          - '0'
+        X-Content-Type-Options:
+          - nosniff
+        X-Download-Options:
+          - noopen
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Content-Type:
+          - application/json; charset=utf-8
+        Etag:
+          - W/"0f5d5a482ba6f6631cd61c5044991357"
+        Cache-Control:
+          - max-age=0, private, must-revalidate
+        X-Request-Id:
+          - ca25b7dc-057c-45d7-8008-ba3d23003b2a
+        X-Runtime:
+          - '0.295747'
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Vary:
+          - Origin
+        Content-Length:
+          - '2023'
+        Via:
+          - 1.1 vegur
+      body:
+        encoding: UTF-8
+        string: '{ "production_schedule_slots": [ { "id":"d81acfa2-19e3-4ae3-ae1e-e0db4e8d02b9", "machine_id":"54a042b2-e09c-4ced-bf3c-0f8c43f8a522", "created_at":"2023-05-15T13:50:58.390Z", "updated_at":"2023-05-15T13:50:58.390Z", "starts_at":"2023-05-15T00:00:00.000Z", "ends_at":"2023-05-15T02:00:00.000Z", "workstep":{ "id":"dfe2e539-697e-4eb3-a806-a267a578f8b0", "created_at":"2023-05-15T13:50:58.375Z", "updated_at":"2023-05-15T13:50:58.375Z", "kind":"inkjet_printing", "state":"pending", "expected_total_duration":148255, "progress":0.0 } }, { "id":"0dd665a7-22a3-466a-953a-17d16f388acf", "machine_id":"54a042b2-e09c-4ced-bf3c-0f8c43f8a522", "created_at":"2023-05-15T13:50:58.400Z", "updated_at":"2023-05-15T13:50:58.400Z", "starts_at":"2023-05-15T02:00:00.000Z", "ends_at":"2023-05-15T04:00:00.000Z", "workstep":{ "id":"dc426458-629d-46f9-b607-fb88c51146a1", "created_at":"2023-05-15T13:50:58.393Z", "updated_at":"2023-05-15T13:50:58.393Z", "kind":"digital_printing", "state":"running", "expected_total_duration":120597, "progress":0.0 } }, { "id":"1d9bb577-7202-4f92-9d7f-78488dbcaa76", "machine_id":"54a042b2-e09c-4ced-bf3c-0f8c43f8a522", "created_at":"2023-05-15T13:50:58.409Z", "updated_at":"2023-05-15T13:50:58.409Z", "starts_at":"2023-05-15T04:00:00.000Z", "ends_at":"2023-05-15T06:00:00.000Z", "workstep":{ "id":"77a31c5b-cf3a-476f-b4ad-c266ed4e2764", "created_at":"2023-05-15T13:50:58.402Z", "updated_at":"2023-05-15T13:50:58.402Z", "kind":"engraving", "state":"paused", "expected_total_duration":203081, "progress":0.0 } } ] }'
+    recorded_at: Tue, 04 Apr 2023 07:40:13 GMT
+recorded_with: VCR 6.1.0

--- a/test/zaikio/mission_control_test.rb
+++ b/test/zaikio/mission_control_test.rb
@@ -192,4 +192,17 @@ class Zaikio::MissionControlTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "fetch a machine production schedules" do
+    VCR.use_cassette("machine_production_schedule") do
+      Zaikio::MissionControl.with_token(token) do
+        slots = Zaikio::MissionControl::Machine
+                .new(id: "b1cc3531-ea11-4f94-b35f-cccaaed4a4c5")
+                .production_schedule_slots
+
+        assert_equal 3, slots.count
+        assert(slots.all? { |slot| slot.is_a?(Zaikio::MissionControl::Slot) })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Enhance the gem to provide a way for Keyline to sync the production slots for connected machines.

Solves https://github.com/zaikio/keyline/issues/3113