### PR TITLE
Include root in JSON payload for OrderLineItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Include root in JSON payload for `OrderLineItem`
+
 ## [0.2.10]
 
 - Include root in JSON payload for `Execution`

--- a/lib/zaikio/mission_control/order_line_item.rb
+++ b/lib/zaikio/mission_control/order_line_item.rb
@@ -1,6 +1,8 @@
 module Zaikio
   module MissionControl
     class OrderLineItem < Base
+      include_root_in_json :execution
+
       attributes :id, :references, :kind, :job_id, :quantity, :unit, :description, :net_price, :net_total_price,
                  :gross_price, :gross_total_price, :order_number, :taxes, :tax_rate, :created_at, :updated_at, :shipping_option_id
     end


### PR DESCRIPTION
Needed for Web2Print integration, as payload updates are required to have the model name key
also hopefully refresh rubygems as it struggle to make v.0.2.10 available