### PR TITLE
Refactor Jobs' definition

### DIFF
--- a/lib/zaikio/mission_control.rb
+++ b/lib/zaikio/mission_control.rb
@@ -128,13 +128,13 @@ module Zaikio
         @job_klasses ||= Zaikio::MissionControl::Jobs
                          .constants.sort
                          .map { |c| Zaikio::MissionControl::Jobs.const_get(c) }
-                         .select { |c| c.is_a?(Class) } - [Zaikio::MissionControl::Jobs::Base]
+                         .select { |c| c.is_a?(Class) && !(c < ActiveSupport::TestCase) } - [Zaikio::MissionControl::Jobs::Base]
       end
 
       def part_klasses
         @part_klasses ||= Zaikio::MissionControl::Parts.constants.sort
                                                        .map { |c| Zaikio::MissionControl::Parts.const_get(c) }
-                                                       .select { |c| c.is_a?(Class) }  - [Zaikio::MissionControl::Parts::Base]
+                                                       .select { |c| c.is_a?(Class) } - [Zaikio::MissionControl::Parts::Base]
       end
 
       def finishing_klasses

--- a/lib/zaikio/mission_control/jobs/base.rb
+++ b/lib/zaikio/mission_control/jobs/base.rb
@@ -3,16 +3,6 @@ module Zaikio
     module Jobs
       class Base < Zaikio::MissionControl::Base
         class << self
-          def has_one_part(name, required: false) # rubocop:disable Naming/PredicateName
-            @parts ||= {}
-            @parts[name] = { required: required, multiples: false }
-          end
-
-          def has_many_parts(name, required: false) # rubocop:disable Naming/PredicateName
-            @parts ||= {}
-            @parts[name.to_s.singularize.to_sym] = { required: required, multiples: true }
-          end
-
           def parts
             @parts ||= {}
             @parts.keys
@@ -36,7 +26,7 @@ module Zaikio
           end
 
           def multiples?(part_name_or_klass)
-            part_config(part_name_or_klass)[:multiples]
+            part_config(part_name_or_klass)[:multiple]
           end
 
           def required?(part_name_or_klass)

--- a/lib/zaikio/mission_control/jobs/booklet.rb
+++ b/lib/zaikio/mission_control/jobs/booklet.rb
@@ -2,10 +2,12 @@ module Zaikio
   module MissionControl
     module Jobs
       class Booklet < Base
-        has_many_parts :contents, required: true
-        has_one_part :cover
-        has_many_parts :inserts
-        has_many_parts :outserts
+        @parts = {
+          cover: { required: true, multiple: false },
+          content: { required: true, multiple: true },
+          insert: { required: false, multiple: true },
+          outsert: { required: false, multiple: true }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/box.rb
+++ b/lib/zaikio/mission_control/jobs/box.rb
@@ -2,8 +2,10 @@ module Zaikio
   module MissionControl
     module Jobs
       class Box < Base
-        has_one_part :base, required: true
-        has_one_part :lid, required: true
+        @parts = {
+          base: { required: true, multiple: false },
+          lid: { required: true, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/brochure.rb
+++ b/lib/zaikio/mission_control/jobs/brochure.rb
@@ -2,10 +2,12 @@ module Zaikio
   module MissionControl
     module Jobs
       class Brochure < Base
-        has_many_parts :contents, required: true
-        has_one_part :cover, required: true
-        has_many_parts :inserts
-        has_many_parts :outserts
+        @parts = {
+          content: { required: true, multiple: true },
+          cover: { required: false, multiple: false },
+          insert: { required: false, multiple: false },
+          outsert: { required: false, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/business_card.rb
+++ b/lib/zaikio/mission_control/jobs/business_card.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class BusinessCard < Base
-        has_many_parts :business_cards, required: true
+        @parts = { business_card: { required: true, multiple: true } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/carton.rb
+++ b/lib/zaikio/mission_control/jobs/carton.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Carton < Base
-        has_one_part :carton, required: true
+        @parts = { carton: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/carton_two_piece.rb
+++ b/lib/zaikio/mission_control/jobs/carton_two_piece.rb
@@ -2,8 +2,10 @@ module Zaikio
   module MissionControl
     module Jobs
       class CartonTwoPiece < Base
-        has_one_part :base, required: true
-        has_one_part :lid, required: true
+        @parts = {
+          base: { required: true, multiple: false },
+          lid: { required: true, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/compliment_slip.rb
+++ b/lib/zaikio/mission_control/jobs/compliment_slip.rb
@@ -2,7 +2,9 @@ module Zaikio
   module MissionControl
     module Jobs
       class ComplimentSlip < Base
-        has_one_part :compliment_slip, required: true
+        @parts = {
+          compliment_slip: { required: true, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/continuation_sheet.rb
+++ b/lib/zaikio/mission_control/jobs/continuation_sheet.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class ContinuationSheet < Base
-        has_one_part :continuation_sheet, required: true
+        @parts = { continuation_sheet: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/cover_letter.rb
+++ b/lib/zaikio/mission_control/jobs/cover_letter.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class CoverLetter < Base
-        has_one_part :cover_letter, required: true
+        @parts = { cover_letter: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/envelope.rb
+++ b/lib/zaikio/mission_control/jobs/envelope.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Envelope < Base
-        has_one_part :envelope, required: true
+        @parts = { envelope: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/flyer.rb
+++ b/lib/zaikio/mission_control/jobs/flyer.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Flyer < Base
-        has_one_part :flyer, required: true
+        @parts = { flyer: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/folder.rb
+++ b/lib/zaikio/mission_control/jobs/folder.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Folder < Base
-        has_many_parts :folders, required: true
+        @parts = { folder: { required: true, multiple: true } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/folding_card.rb
+++ b/lib/zaikio/mission_control/jobs/folding_card.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class FoldingCard < Base
-        has_many_parts :folding_cards, required: true
+        @parts = { folding_card: { required: true, multiple: true } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/hardcover_book.rb
+++ b/lib/zaikio/mission_control/jobs/hardcover_book.rb
@@ -2,10 +2,12 @@ module Zaikio
   module MissionControl
     module Jobs
       class HardcoverBook < Base
-        has_many_parts :contents, required: true
-        has_one_part :case, required: true
-        has_many_parts :endpapers, required: true
-        has_one_part :jacket
+        @parts = {
+          case: { required: true, multiple: false },
+          content: { required: true, multiple: true },
+          endpaper: { required: true, multiple: true },
+          jacket: { required: false, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/label.rb
+++ b/lib/zaikio/mission_control/jobs/label.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Label < Base
-        has_one_part :label, required: true
+        @parts = { label: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/leaflet.rb
+++ b/lib/zaikio/mission_control/jobs/leaflet.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Leaflet < Base
-        has_one_part :leaflet, required: true
+        @parts = { leaflet: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/letter_head.rb
+++ b/lib/zaikio/mission_control/jobs/letter_head.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class LetterHead < Base
-        has_one_part :letter_head, required: true
+        @parts = { letter_head: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/magazine.rb
+++ b/lib/zaikio/mission_control/jobs/magazine.rb
@@ -2,10 +2,12 @@ module Zaikio
   module MissionControl
     module Jobs
       class Magazine < Base
-        has_one_part :content, required: true
-        has_one_part :cover
-        has_many_parts :inserts
-        has_many_parts :outserts
+        @parts = {
+          content: { required: true, multiple: true },
+          cover: { required: true, multiple: false },
+          insert: { required: false, multiple: false },
+          outsert: { required: false, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/map.rb
+++ b/lib/zaikio/mission_control/jobs/map.rb
@@ -2,8 +2,10 @@ module Zaikio
   module MissionControl
     module Jobs
       class Map < Base
-        has_one_part :map_sheet, required: true
-        has_one_part :cover
+        @parts = {
+          cover: { required: false, multiple: false },
+          map_sheet: { required: true, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/ncr_pad.rb
+++ b/lib/zaikio/mission_control/jobs/ncr_pad.rb
@@ -2,9 +2,11 @@ module Zaikio
   module MissionControl
     module Jobs
       class NcrPad < Base
-        has_many_parts :content, required: true
-        has_one_part :back, required: true
-        has_one_part :cover
+        @parts = {
+          content: { required: true, multiple: true },
+          back: { required: true, multiple: false },
+          cover: { required: false, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/newspaper.rb
+++ b/lib/zaikio/mission_control/jobs/newspaper.rb
@@ -2,8 +2,10 @@ module Zaikio
   module MissionControl
     module Jobs
       class Newspaper < Base
-        has_one_part :content, required: true
-        has_many_parts :inserts
+        @parts = {
+          content: { required: true, multiple: true },
+          insert: { required: false, multiple: true }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/notebook.rb
+++ b/lib/zaikio/mission_control/jobs/notebook.rb
@@ -2,9 +2,11 @@ module Zaikio
   module MissionControl
     module Jobs
       class Notebook < Base
-        has_many_parts :contents, required: true
-        has_one_part :cover, required: true
-        has_one_part :back
+        @parts = {
+          content: { required: true, multiple: true },
+          cover: { required: true, multiple: false },
+          back: { required: false, multiple: false }
+        }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/postcard.rb
+++ b/lib/zaikio/mission_control/jobs/postcard.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Postcard < Base
-        has_one_part :postcard, required: true
+        @parts = { postcard: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/poster.rb
+++ b/lib/zaikio/mission_control/jobs/poster.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Poster < Base
-        has_one_part :poster, required: true
+        @parts = { poster: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/self_mailer.rb
+++ b/lib/zaikio/mission_control/jobs/self_mailer.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class SelfMailer < Base
-        has_one_part :self_mailer, required: true
+        @parts = { self_mailer: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/sheet.rb
+++ b/lib/zaikio/mission_control/jobs/sheet.rb
@@ -2,7 +2,7 @@ module Zaikio
   module MissionControl
     module Jobs
       class Sheet < Base
-        has_one_part :sheet, required: true
+        @parts = { sheet: { required: true, multiple: false } }
       end
     end
   end

--- a/lib/zaikio/mission_control/jobs/softcover_book.rb
+++ b/lib/zaikio/mission_control/jobs/softcover_book.rb
@@ -2,8 +2,10 @@ module Zaikio
   module MissionControl
     module Jobs
       class SoftcoverBook < Base
-        has_one_part :content, required: true
-        has_one_part :cover, required: true
+        @parts = {
+          content: { required: true, multiple: true },
+          cover: { required: true, multiple: false }
+        }
       end
     end
   end

--- a/test/zaikio/mission_control/jobs/jobs_test.rb
+++ b/test/zaikio/mission_control/jobs/jobs_test.rb
@@ -50,8 +50,8 @@ class Zaikio::MissionControl::JobsTest < ActiveSupport::TestCase
       "FoldingCard" => {
         folding_card: { required: true, multiple: true }
       },
-      "HardcoverBook" => { content: { required: true, multiples: true },
-                           case: { required: true, multiples: false }, endpaper: { required: true, multiples: true }, jacket: { required: false, multiples: false } },
+      "HardcoverBook" => { content: { required: true, multiple: true },
+                           case: { required: true, multiple: false }, endpaper: { required: true, multiple: true }, jacket: { required: false, multiple: false } },
       "Label" => {
         label: { required: true, multiple: false }
       },
@@ -110,20 +110,20 @@ class Zaikio::MissionControl::JobsTest < ActiveSupport::TestCase
   end
 
   test ".parts, return what it should" do
-    expected = %i[content case endpaper jacket]
+    expected = %i[case content endpaper jacket]
 
     assert_equal expected,
                  Zaikio::MissionControl::Jobs::HardcoverBook.parts
   end
 
   test ".part_config, return what it should" do
-    expected = { required: true, multiples: true }
+    expected = { required: true, multiple: true }
     assert_equal expected,
                  Zaikio::MissionControl::Jobs::HardcoverBook.part_config(:content)
   end
 
   test ".part_klasses, return what it should" do
-    expected = [Zaikio::MissionControl::Parts::Content, Zaikio::MissionControl::Parts::Case,
+    expected = [Zaikio::MissionControl::Parts::Case, Zaikio::MissionControl::Parts::Content,
                 Zaikio::MissionControl::Parts::Endpaper, Zaikio::MissionControl::Parts::Jacket]
 
     assert_equal expected,

--- a/test/zaikio/mission_control_test.rb
+++ b/test/zaikio/mission_control_test.rb
@@ -171,8 +171,8 @@ class Zaikio::MissionControlTest < ActiveSupport::TestCase
   test "returns jobs and parts config" do
     assert_equal(
       %i[
-        content
         cover
+        content
         insert
         outsert
       ],
@@ -185,8 +185,8 @@ class Zaikio::MissionControlTest < ActiveSupport::TestCase
     assert Zaikio::MissionControl::Jobs::Booklet.required?(Zaikio::MissionControl::Parts::Content)
     assert_equal(
       [
-        Zaikio::MissionControl::Parts::Content,
         Zaikio::MissionControl::Parts::Cover,
+        Zaikio::MissionControl::Parts::Content,
         Zaikio::MissionControl::Parts::Insert,
         Zaikio::MissionControl::Parts::Outsert
       ],


### PR DESCRIPTION
Replace the macro style definition by hash declaration.

This removes some of the complexity and make it easier to update jobs from Mission Control since we're already using hash to define Jobs. [See job_kind.rb](https://github.com/zaikio/zai-mission-control/blob/main/app/models/job_kind.rb)