### PR TITLE
Bump to v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2]
+
+- Fix `Folder` and `FoldingCard` Mission Control `Job` kinds being listed as available kinds 
+
 ## [0.4.1]
 
 - Add `belongs_to` relationship to `Execution` for `Workstep`
@@ -79,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add finishings specification
 - Add jobs and parts specification
 
-[Unreleased]: https://github.com/zaikio/zaikio-mission_control-ruby/compare/v0.4.1..HEAD
+[Unreleased]: https://github.com/zaikio/zaikio-mission_control-ruby/compare/v0.4.2..HEAD
+[0.4.2]: https://github.com/zaikio/zaikio-mission_control-ruby/compare/v0.4.0..v0.4.2
 [0.4.1]: https://github.com/zaikio/zaikio-mission_control-ruby/compare/v0.4.0..v0.4.1
 [0.4.0]: https://github.com/zaikio/zaikio-mission_control-ruby/compare/v0.3.0..v0.4.0
 [0.3.0]: https://github.com/zaikio/zaikio-mission_control-ruby/compare/v0.2.12..v0.3.0

--- a/lib/zaikio/mission_control/version.rb
+++ b/lib/zaikio/mission_control/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module MissionControl
-    VERSION = "0.4.1".freeze
+    VERSION = "0.4.2".freeze
   end
 end


### PR DESCRIPTION
Previous version did not included fixes from Yann to reference new `Job` `kinds`. This new version includes the mentioned fixes.